### PR TITLE
Configure `repository` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Serverless framework plugin to configure binary support for API Gateway endpoints",
   "main": "index.js",
+  "repository": "ryanmurakami/serverless-apigwy-binary",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Currently [npm page](https://www.npmjs.com/package/serverless-apigwy-binary) doesn't communicate where this project is maintained. This PR fixes that