### PR TITLE
Configure deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # serverless-apigwy-binary
 
+## DEPRECATED
+
+Functionality as provided by plugin is available in Serverless Framework natively (since v1.59.0)
+
+`contentHandling` on `http` event responses can be confgured simply as:
+
+```yaml
+functions:
+  someFunction:
+    events:
+      - http:
+          ....
+          response:
+            contentHandling: CONVERT_TO_BINARY
+```
+
+## Legacy Documentation
+
 [Serverless framework](https://www.serverless.com) plugin to configure Binary responses in API Gateway
 
 Original code from [codebox](https://github.com/craftship/codebox-npm/blob/master/.serverless_plugins/content-handling/index.js)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const BbPromise = require('bluebird')
+const semver = require('semver')
 
 class ApiGwyBinaryPlugin {
   constructor (serverless, options) {
@@ -7,6 +8,15 @@ class ApiGwyBinaryPlugin {
     this.provider = this.serverless.getProvider('aws')
 
     this.hooks = {
+      initialize: () => {
+        if (!serverless.version || !serverless.logDeprecation) return;
+        if (!semver.gte(serverless.version, '1.59.0')) return;
+        serverless.logDeprecation(
+          'OBSOLETE_APIGWY_BINARY_PLUGIN',
+          '"serverless-apigwy-binary" plugin is no longer needed. Please uninstall it as it will not work with next Framework major release.\n' +
+            'To migrate simply configure setting in following way "functions[].events.http.responce.contentHandling: CONVERT_TO_BINARY"'
+        );
+      },
       'after:aws:deploy:deploy:updateStack': this.configureApiGwy.bind(this)
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.5.0"
+  },
+  "peerDependencies": {
+    "serverless": "1 || 2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "author": "Ryan Lewis<ryan@ryanhlewis.com",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.5.0"
+    "bluebird": "^3.5.0",
+    "semver": "^7.3.5"
   },
   "peerDependencies": {
     "serverless": "1 || 2"


### PR DESCRIPTION
As this plugin is obsolete, it'll be great to explicitly state it in documentation and log deprecation warning to its users.

This PR introduces needed changes